### PR TITLE
Build libarchive with zstd support

### DIFF
--- a/org.kde.ark.json
+++ b/org.kde.ark.json
@@ -75,6 +75,21 @@
             ]
         },
         {
+            "name": "zstd",
+            "buildsystem": "simple",
+            "build-commands": [
+                "make",
+                "make PREFIX=/ DESTDIR=\"${FLATPAK_DEST}\" install"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/facebook/zstd/releases/download/v1.4.5/zstd-1.4.5.tar.gz",
+                    "sha256": "98e91c7c6bf162bf90e4e70fdbc41a8188b9fa8de5ad840c401198014406ce9e"
+                }
+            ]
+        },
+        {
             "name": "ark",
             "buildsystem": "cmake-ninja",
             "sources": [

--- a/org.kde.ark.json
+++ b/org.kde.ark.json
@@ -23,6 +23,21 @@
     ],
     "modules": [
         {
+            "name": "zstd",
+            "buildsystem": "simple",
+            "build-commands": [
+                "make",
+                "make PREFIX=/ DESTDIR=\"${FLATPAK_DEST}\" install"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/facebook/zstd/releases/download/v1.4.5/zstd-1.4.5.tar.gz",
+                    "sha256": "98e91c7c6bf162bf90e4e70fdbc41a8188b9fa8de5ad840c401198014406ce9e"
+                }
+            ]
+        },
+        {
             "name": "libarchive",
             "config-opts": ["--without-xml2"],
             "sources": [
@@ -71,21 +86,6 @@
                     "type": "archive",
                     "url": "https://github.com/ckolivas/lrzip/archive/v0.631.tar.gz",
                     "sha256": "10315c20d5a47590e7220c210735ba169677824d5672509266682eccec84d952"
-                }
-            ]
-        },
-        {
-            "name": "zstd",
-            "buildsystem": "simple",
-            "build-commands": [
-                "make",
-                "make PREFIX=/ DESTDIR=\"${FLATPAK_DEST}\" install"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/facebook/zstd/releases/download/v1.4.5/zstd-1.4.5.tar.gz",
-                    "sha256": "98e91c7c6bf162bf90e4e70fdbc41a8188b9fa8de5ad840c401198014406ce9e"
                 }
             ]
         },


### PR DESCRIPTION
It turns out that libarchive was built without zstd support. We need right build order there. :)