### PR TITLE
Add lz4 support

### DIFF
--- a/org.kde.ark.json
+++ b/org.kde.ark.json
@@ -38,6 +38,22 @@
             ]
         },
         {
+            "name": "lz4",
+            "buildsystem": "simple",
+            "build-commands": [
+                "make -C lib PREFIX=/",
+                "make -C programs PREFIX=/usr lz4 lz4",
+                "make install PREFIX=/ DESTDIR=\"${FLATPAK_DEST}\" install"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/lz4/lz4/archive/v1.9.2.tar.gz",
+                    "sha256": "658ba6191fa44c92280d4aa2c271b0f4fbc0e34d249578dd05e50e76d0e5efcc"
+                }
+            ]
+        },
+        {
             "name": "libarchive",
             "config-opts": ["--without-xml2"],
             "sources": [


### PR DESCRIPTION
This should add lz4 support via libarchive. Will do testing with the test build.