### PR TITLE
Improved ReadMe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ark (org.kde.ark)
+# Ark (`org.kde.ark`)
 
 [Homepage](https://kde.org/applications/utilities/ark/) |
 [User documentation](https://docs.kde.org/stable5/en/kdeutils/ark/index.html) |
@@ -6,16 +6,11 @@
 
 ## Reporting bugs
 
-**Before filling a bug, please test if the bug is reproduceable with the
-classic non-Flatpak version of this application.**
+**Before filling a bug, please test if the bug is reproducible with the classic non-Flatpak version of this application.**
 
-- If the bug is only reproducible with the **Flatpak version** of this
-  application, please file an [Issue here][issue].
+- If the bug is only reproducible with the **Flatpak version** of this application, please file an [Issue here][issue].
 
-- If the bug is also reproducible with the **non-Flatpak version** of this
-  application, please take a look at the [currently opened bugs][bugs] and if
-  it has not been reported yet, file a bug at
-  [bugs.kde.org](https://bugs.kde.org).
+- If the bug is also reproducible with the **non-Flatpak version** of this application, please take a look at the [currently opened bugs][bugs] and if it has not been reported yet, file a bug at [bugs.kde.org](https://bugs.kde.org).
 
 **If you have any doubt, please file an [Issue here][issue].**
 
@@ -23,9 +18,7 @@ classic non-Flatpak version of this application.**
 
 This application requests the following restricted permissions:
 
-- Required to extract an archive to a user chosen path: `--filesystem=host`.
-  This could potentially be removed in favor of a portal based approach but
-  this currently requires development work.
+- Required to extract an archive to a user-chosen path: `--filesystem=host`. This could potentially be removed in favor of a portal-based approach, but this currently requires development work.
 
 [issue]: https://github.com/flathub/org.kde.ark/issues/new
-[bugs]: https://bugs.kde.org/buglist.cgi?bug_status=UNCONFIRMED&bug_status=CONFIRMED&bug_status=ASSIGNED&bug_status=REOPENED&product=ark&query_format=advanced
+[bugs]:  https://bugs.kde.org/buglist.cgi?bug_status=UNCONFIRMED&bug_status=CONFIRMED&bug_status=ASSIGNED&bug_status=REOPENED&product=ark&query_format=advanced


### PR DESCRIPTION
1.  Corrected grammatical errors, like replacing erroneously unhyphenated compound nouns with hyphenated versions.
1.  Concatenated erroneously separated lines, because:
	1.	Markdown needs (ideally) to be readable in textual form, which necessitates that arbitrary line breaks not be present, lest it be unreadable on any display not of the now-standard 16:9 (like a smartphone's, in portrait).
	1.	It prevents spell-checkers operating.
1.  Aligned the items in the bibliography.
1.  Codified (`<code>`) the "`org.kde.ark`" clause to demonstrate that it's technical.