### PR TITLE
Update p7zip to 17.06

### DIFF
--- a/org.kde.ark.json
+++ b/org.kde.ark.json
@@ -173,16 +173,13 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/p7zip-project/p7zip/archive/v17.04/p7zip-v17.04.tar.gz",
-                    "sha256": "ea029a2e21d2d6ad0a156f6679bd66836204aa78148a4c5e498fe682e77127ef",
+                    "url": "https://github.com/p7zip-project/p7zip/archive/v17.06/p7zip-v17.06.tar.gz",
+                    "sha256": "c35640020e8f044b425d9c18e1808ff9206dc7caf77c9720f57eb0849d714cd1",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 2583,
                         "stable-only": true,
-                        "url-template": "https://github.com/p7zip-project/p7zip/archive/v$version/p7zip-v$version.tar.gz",
-                        "versions": {
-                            "<": "17.05"
-                        }
+                        "url-template": "https://github.com/p7zip-project/p7zip/archive/v$version/p7zip-v$version.tar.gz"
                     }
                 },
                 {


### PR DESCRIPTION
Updated, installed, confirmed 7z file https://getsamplefiles.com/download/7z/sample-1.7z opened and extracted successfully.

Fixes #81